### PR TITLE
Security: Add `packages/contracts/.env` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+packages/contracts/.env


### PR DESCRIPTION
Help prevent other users from accidentally leaking their private keys by ensuring the `packages/contracts/.env` path described in `README.md` to contain private keys is by default ignored by git.